### PR TITLE
Weakify

### DIFF
--- a/HTagView/Classes/HTag.swift
+++ b/HTagView/Classes/HTag.swift
@@ -15,7 +15,7 @@ protocol HTagDelegate: class {
 
 class HTag: UIButton {
     
-    var delegate: HTagDelegate?
+    weak var delegate: HTagDelegate?
     
     var tagString : String = ""{
         didSet{
@@ -59,7 +59,7 @@ class HTag: UIButton {
     
     
     
-    func tagClicked(){
+    @objc func tagClicked(){
         if withCancelButton{
             delegate?.tagCancelled(self)
         }else{

--- a/HTagView/Classes/HTagView.swift
+++ b/HTagView/Classes/HTagView.swift
@@ -12,7 +12,7 @@ import UIKit
  HTagViewDelegate is a protocol to implement for responding to user interactions to the HTagView.
  */
 @objc
-public protocol HTagViewDelegate {
+public protocol HTagViewDelegate: class {
 //    optional func tagView(tagView: HTagView, didCancelTag tagTitle: String)
     @objc optional func tagView(_ tagView: HTagView, didCancelTagAtIndex index: Int)
 //    optional func tagView(tagView: HTagView, tagSelectionDidChange tagSelected: [String])
@@ -22,7 +22,7 @@ public protocol HTagViewDelegate {
 /**
  HTagViewDataSource is a protocol to implement for data source of the HTagView.
  */
-public protocol HTagViewDataSource {
+public protocol HTagViewDataSource: class {
     func numberOfTags(_ tagView: HTagView) -> Int
     func tagView(_ tagView: HTagView, titleOfTagAtIndex index: Int) -> String
     func tagView(_ tagView: HTagView, tagTypeAtIndex index: Int) -> HTagType
@@ -51,7 +51,7 @@ open class HTagView: UIView, HTagDelegate {
     /**
      HTagViewDataSource
      */
-    open var dataSource : HTagViewDataSource?{
+    open weak var dataSource : HTagViewDataSource?{
         didSet{
             reloadData()
         }
@@ -61,7 +61,7 @@ open class HTagView: UIView, HTagDelegate {
     /**
      HTagViewDelegate
      */
-    open var delegate : HTagViewDelegate?
+    open weak var delegate : HTagViewDelegate?
     
     // MARK: - HTagView Configuration
     /**


### PR DESCRIPTION
Setting datasource and delegate as `weak var` to avoid retain cycle.
Class bounded those protocols to `class`
Added @objc modifier to needed method used by ObjC API ( `addTarget` using a #selector)